### PR TITLE
Add mvn build argument -Drelease.version=x.x.x

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -338,7 +338,6 @@
                                 <phase>process-resources</phase>
                                 <configuration>
                                     <failOnError>false</failOnError>
-                                    
                                     <target>
                                         <tstamp>
                                             <format property="ignite.rel.date" pattern="ddMMyyyy" locale="en" />
@@ -360,12 +359,12 @@
                                             <regexp pattern="ignite.update.status.params=.*" />
                                             <substitution expression="ignite.update.status.params=ver=${project.version}&amp;product=${ignite.update.notifier.product}" />
                                         </replaceregexp>
-                                        
+
                                         <replaceregexp file="${props.file}" byline="true">
                                             <regexp pattern="ignite.version=.*" />
                                             <substitution expression="ignite.version=${project.version}" />
-                                        </replaceregexp>                                            
-                                        
+                                        </replaceregexp>
+
                                         <!-- git (to be replaced by git hooks)-->
 
                                         <exec executable="${git.exec}" outputproperty="ignite.build" failonerror="true">
@@ -395,8 +394,7 @@
                                             <regexp pattern="ignite.version=.*" />
                                             <substitution expression="ignite.version=${release.version}" />
                                         </replaceregexp>
-                                    </target>
-                                    
+                                    </target>                                    
                                 </configuration>
                             </execution>
                         </executions>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -338,6 +338,7 @@
                                 <phase>process-resources</phase>
                                 <configuration>
                                     <failOnError>false</failOnError>
+                                    
                                     <target>
                                         <tstamp>
                                             <format property="ignite.rel.date" pattern="ddMMyyyy" locale="en" />
@@ -359,12 +360,12 @@
                                             <regexp pattern="ignite.update.status.params=.*" />
                                             <substitution expression="ignite.update.status.params=ver=${project.version}&amp;product=${ignite.update.notifier.product}" />
                                         </replaceregexp>
-
+                                        
                                         <replaceregexp file="${props.file}" byline="true">
                                             <regexp pattern="ignite.version=.*" />
                                             <substitution expression="ignite.version=${project.version}" />
-                                        </replaceregexp>
-
+                                        </replaceregexp>                                            
+                                        
                                         <!-- git (to be replaced by git hooks)-->
 
                                         <exec executable="${git.exec}" outputproperty="ignite.build" failonerror="true">
@@ -385,6 +386,17 @@
                                             <substitution expression="ignite.build=${ignite.build}" />
                                         </replaceregexp>
                                     </target>
+                                    
+                                    <!-- called mvn -Drelease.version=2.4.0 -->
+                                    <target if="release.version">
+                                        <property name="props.file" value="../../modules/core/target/classes/ignite.properties" />
+                                        
+                                        <replaceregexp file="${props.file}" byline="true">
+                                            <regexp pattern="ignite.version=.*" />
+                                            <substitution expression="ignite.version=${release.version}" />
+                                        </replaceregexp>
+                                    </target>
+                                    
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Execute Ignite build with 'mvn clean install -Pall-java,all-scala,licenses -DskipTests -Drelease.version=2.4.0'.
The added mvn argument -Drelease.version=2.4.0 sets proper version in ignite.properties file at build time. 