### PR TITLE
Initial prod docker image review

### DIFF
--- a/modules/docker/2.4.0-jobcase/prod/Dockerfile
+++ b/modules/docker/2.4.0-jobcase/prod/Dockerfile
@@ -1,0 +1,125 @@
+# Base image for Jobcase Apache Ignite
+
+# Docker image layout:
+#  |
+#  - /opt/jobcase
+#     |
+#     | entrypoint.sh
+#     |- logs
+#     |- config
+#     |- apache-ignite-fabric
+#        |
+#        | run.sh
+#        |- bin
+#        |- libs
+#        |- config
+#
+
+# Start from a Java image.
+FROM openjdk:8
+
+# Ignite version
+ENV IGNITE_VERSION 2.4.0
+
+# JobCase home
+ENV JOBCASE_HOME /opt/jobcase
+
+# Location of configuration files
+ENV JOBCASE_CONFIG ${JOBCASE_HOME}/config
+
+# Location of container log files
+ENV JOBCASE_LOGS ${JOBCASE_HOME}/logs
+
+# Ports
+ENV IGNITE_SERVER_PORT 11211
+ENV IGNITE_JMX_PORT 49112
+ENV IGNITE_DISCOVERY_PORT 47500
+ENV IGNITE_COMMUNICATION_PORT 47100
+ENV IGNITE_JDBC_PORT 10800
+ENV IGNITE_REST_PORT 8080
+
+# verbose mode in Ignite
+ENV IGNITE_QUIET false
+
+# Default Ignite cluster definition file
+ENV CONFIG_URI ${JOBCASE_CONFIG}/multicast.discovery.node.config.xml
+
+# root directory where Ignite will persist data, indexes and so on
+ENV IGNITE_PERSISTANT_STORE ${JOBCASE_HOME}/db
+
+# ip dicovery volume
+ENV IGNITE_DISCOVERY /opt/jobcase/discovery
+
+# Ignite home
+ENV IGNITE_HOME ${JOBCASE_HOME}/apache-ignite-fabric
+
+# Initial and maximum JVM Heap size
+ENV JVM_HEAP_SIZE 1g
+
+# JVM maximum amount of native memory that can be allocated for class metadata 
+ENV JVM_METASPACE_SIZE 1g
+
+# Ignite JVM settings
+ENV JVM_OPTS="-XX:MaxMetaspaceSize=${JVM_METASPACE_SIZE} -server -Xms${JVM_HEAP_SIZE} -Xmx${JVM_HEAP_SIZE} -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:+DisableExplicitGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M -Xloggc:${JOBCASE_LOGS}/jvm-gc.log"
+
+# Do not rely on anything provided by base image(s), but be explicit, if they are installed already it is noop then
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        unzip \
+        curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p ${JOBCASE_LOGS}
+        
+# Copy apache ignite binaries
+COPY ./apache-ignite-fabric-${IGNITE_VERSION}-SNAPSHOT-bin ${IGNITE_HOME}/
+
+# Enable log4j2
+COPY ./apache-ignite-fabric-${IGNITE_VERSION}-SNAPSHOT-bin/libs/optional/ignite-log4j2 ${IGNITE_HOME}/libs/ignite-log4j2/
+
+# Enable HTTP REST client
+COPY ./apache-ignite-fabric-${IGNITE_VERSION}-SNAPSHOT-bin/libs/optional/ignite-rest-http ${IGNITE_HOME}/libs/ignite-rest-http/
+
+# Enable AWS support
+COPY ./apache-ignite-fabric-${IGNITE_VERSION}-SNAPSHOT-bin/libs/optional/ignite-aws ${IGNITE_HOME}/libs/ignite-aws/
+
+# Copy log4j2 configuration file
+COPY ./ignite-log4j2.xml ${JOBCASE_CONFIG}/
+
+# Copy REST client configuration file
+COPY ./jetty-config.xml ${JOBCASE_CONFIG}/
+
+# Copy comnmon grid configuration file
+COPY ./common.node.config.xml ${JOBCASE_CONFIG}/
+
+# Copy comnmon grid configuration file
+COPY ./file.discovery.node.config.xml ${JOBCASE_CONFIG}/
+
+# Copy s3 bucket discovery grid configuration file
+COPY ./s3bucket.discovery.node.config.xml ${JOBCASE_CONFIG}/
+
+# Copy default grid configuration file
+COPY ./multicast.discovery.node.config.xml ${JOBCASE_CONFIG}/
+
+# Copy sh files and set permission
+COPY ./run.sh ${IGNITE_HOME}/
+
+RUN chmod +x ${IGNITE_HOME}/run.sh
+
+# The entrypoint.sh script is always executed at container startup.
+# It includes the logic for further runtime configuration and/or operations.
+COPY ./entrypoint.sh ${JOBCASE_HOME}/
+RUN chmod +x ${JOBCASE_HOME}/entrypoint.sh
+COPY ./util.sh ${JOBCASE_HOME}/
+RUN chmod +x ${JOBCASE_HOME}/util.sh
+
+WORKDIR ${JOBCASE_HOME}
+
+# The exec form is required for CMD providing default arguments 
+# instead shell form 'ENTRYPOINT /bin/bash ${JOBCASE_HOME}/entrypoint.sh'.
+# As a limitation, it will not do variable substitution like ${JOBCASE_HOME}.
+# So we call 'WORKDIR ${JOBCASE_HOME}' prior.
+ENTRYPOINT ["/bin/bash", "entrypoint.sh"]
+
+# Set default arguments for ENTRYPOINT
+CMD ["--debug", "--launch", "${IGNITE_HOME}/run.sh &"]
+
+EXPOSE $IGNITE_SERVER_PORT $IGNITE_COMMUNICATION_PORT $IGNITE_DISCOVERY_PORT $IGNITE_JMX_PORT $IGNITE_JDBC_PORT $IGNITE_REST_PORT

--- a/modules/docker/2.4.0-jobcase/prod/Dockerfile
+++ b/modules/docker/2.4.0-jobcase/prod/Dockerfile
@@ -1,5 +1,9 @@
 # Base image for Jobcase Apache Ignite
 
+#
+# The image layout keeps same type of information in dedicated top-level directories. 
+# E. g. all configuration information is in '/opt/jobcase/config'.
+#
 # Docker image layout:
 #  |
 #  - /opt/jobcase
@@ -7,12 +11,12 @@
 #     | entrypoint.sh
 #     |- logs
 #     |- config
+#     |- data
 #     |- apache-ignite-fabric
 #        |
 #        | run.sh
 #        |- bin
 #        |- libs
-#        |- config
 #
 
 # Start from a Java image.
@@ -24,10 +28,15 @@ ENV IGNITE_VERSION 2.4.0
 # JobCase home
 ENV JOBCASE_HOME /opt/jobcase
 
-# Location of configuration files
+# Location of configuration files.
+# # It includes logging configuration file
+# and Apache Ignite grid configuration files 
+# for common deployment scenarios. 
 ENV JOBCASE_CONFIG ${JOBCASE_HOME}/config
 
-# Location of container log files
+# Location of container log files.
+# It includes the entrypoint-, Apache Ignite- 
+# and GC log files.
 ENV JOBCASE_LOGS ${JOBCASE_HOME}/logs
 
 # Ports
@@ -45,12 +54,16 @@ ENV IGNITE_QUIET false
 ENV CONFIG_URI ${JOBCASE_CONFIG}/multicast.discovery.node.config.xml
 
 # root directory where Ignite will persist data, indexes and so on
-ENV IGNITE_PERSISTANT_STORE ${JOBCASE_HOME}/db
+ENV IGNITE_PERSISTANT_STORE ${JOBCASE_HOME}/data
 
-# ip dicovery volume
-ENV IGNITE_DISCOVERY /opt/jobcase/discovery
+# ip dicovery volume for Shared File System Based Discovery
+ENV IGNITE_DISCOVERY_FS ${JOBCASE_HOME}/discovery
+
+# Amazon AWS S3 discovery bucket name
+ENV IGNITE_DISCOVERY_S3_BUCKETNAME staging-mlstore-ignite-discovery-01
 
 # Ignite home
+# It includes the Apache Ignite startup script and binaries. 
 ENV IGNITE_HOME ${JOBCASE_HOME}/apache-ignite-fabric
 
 # Initial and maximum JVM Heap size

--- a/modules/docker/2.4.0-jobcase/prod/Readme.md
+++ b/modules/docker/2.4.0-jobcase/prod/Readme.md
@@ -1,0 +1,438 @@
+# Jobcase Apache Ignite Production Docker Image
+ 
+## Introduction
+
+The docker image includes the Apache Ignite binaries V2.4. The binaries are built from GitHub branch ignite-2.4 [link](https://github.com/percipiomedia/ignite.git).
+
+The docker image follows the control pattern for running commands/scripts at container startup.
+
+## History
+
+* Initial version (5/21/2018): It includes Dockerfile using binaries from GitHub branch build, grid configuration files for multicast-, S3 bucket and file- Apache Ignite node discovery.
+
+## TODO
+
+* Document logging configuration.
+* Add logic for setting setConsistentId with host DNS as suffix.
+* Add remote debug support.
+* Add JMX support.
+* Document Xterm support.
+* Add command for creating schema for binary objects from file ignite-schema.sql.
+* Define and implement healthcheck logic.
+* Add optional command for activating grid.
+* Add optional command for updating baseline topology.
+
+## Terminology
+
+Docker Engine:
+> *It is a client-server application with these major components:* 
+> * *A server which is a type of long-running program called a daemon process (the dockerd command).* 
+> * *A REST API which specifies interfaces that programs can use to talk to the daemon and instruct it what to do.* 
+> * *A command line interface (CLI) client (the docker command).*
+
+> *The daemon creates and manages Docker objects, such as images, containers, networks, and volumes.*
+
+Docker Image: 
+> *An image is an inert, immutable, file that’s essentially a snapshot of a container. Images are created with the build command, and they’ll produce a container when started with run.*
+
+Docker Container:
+> * A container is a runnable instance of an image. You can create, start, stop, move, or delete a container using the Docker API or CLI. You can connect a container to one or more networks, attach storage to it, or even create a new image based on its current state.*
+
+## References
+
+* [1]: https://apacheignite.readme.io/docs/rest-api/ "Apache Ignite REST-API"
+* [2]: https://docs.docker.com/engine/tutorials/networkingcontainers/ "Networking Containers"
+* [3]: https://docs.docker.com/network/overlay/ "Overlay Networks"
+* [4]: https://luppeng.wordpress.com/2018/01/03/revisit-setting-up-an-overlay-network-on-docker-without-docker-swarm/ "Overlay Network Without Swarm"
+* [5]: https://apacheignite.readme.io/docs/distributed-persistent-store "Apache Ignite Persistence"
+* [6]: https://apacheignite.readme.io/docs/jvm-and-system-tuning#garbage-collection-tuning "Apache Ignite Garbage Collection"
+* [7]: http://www.oracle.com/technetwork/articles/java/g1gc-1984535.html "Garbage First Garbage Collector Tuning"
+* [8]: http://www.baeldung.com/jvm-garbage-collectors "JVM Garbage Collectors Overview"
+* [9]: https://apacheignite.readme.io/docs/events "Apache Ignite Events"
+* [10]: https://docs.docker.com/docker-for-mac/faqs/ "Docker for Mac FAQS"
+* [11]: https://docs.docker.com/docker-for-mac/osxfs/ "Docker File System osxfs for Mac"
+* [12]: https://docs.docker.com/docker-for-mac/networking/ "Docker Networking on Mac"
+* [13]: https://github.com/mal/docker-for-mac-host-bridge "Docker for Mac - Host Bridge"
+* [14]: https://apacheignite.readme.io/docs/binary-marshaller "Apache Ignite Binary Marshaller"
+
+## Build
+
+~~~~
+sudo docker build -t apacheignite/jobcase:2.4.0 .
+~~~~
+
+## Networking
+
+The Docker Engine supports different types of networks (bridge, overlay and host).
+The default network type is bridge.
+When Docker gets installed, a default network with the name bridge is created.
+
+List available docker networks:
+
+~~~~
+sudo docker network ls
+~~~~
+
+Inspect default network bridge:
+
+~~~~
+sudo docker network inspect bridge
+
+[
+    {
+        "Name": "bridge",
+        "Id": "71310d36d398903889325ea029e728fad578293e829ee99d3fbab71a563530f3",
+        "Created": "2018-05-18T11:02:54.005764144Z",
+        "Scope": "local",
+        "Driver": "bridge",
+        "EnableIPv6": false,
+        "IPAM": {
+            "Driver": "default",
+            "Options": null,
+            "Config": [
+                {
+                    "Subnet": "172.17.0.0/16",
+                    "Gateway": "172.17.0.1"
+                }
+            ]
+        },
+        "Internal": false,
+        "Attachable": false,
+        "Ingress": false,
+        "ConfigFrom": {
+            "Network": ""
+        },
+        "ConfigOnly": false,
+        "Containers": {},
+        "Options": {
+            "com.docker.network.bridge.default_bridge": "true",
+            "com.docker.network.bridge.enable_icc": "true",
+            "com.docker.network.bridge.enable_ip_masquerade": "true",
+            "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
+            "com.docker.network.bridge.name": "docker0",
+            "com.docker.network.driver.mtu": "1500"
+        },
+        "Labels": {}
+    }
+]
+~~~~
+
+### Bridge Networks
+
+The Docker Engine creates a network interface docker0 for the bridge network on the host. It allows network communication between the host and the docker containers attached to the bridge network.
+**It does not apply to Mac OS X docker hosts (see appendix).**
+
+A bridge network is limited to containers within a single host running the Docker engine.
+
+It is recommend to create your own bridge network:
+
+~~~~
+docker network create
+  --subnet 172.19.0.0/16
+  --gateway 172.19.0.1
+  my-bridge
+~~~~
+
+Attach specific network to container:
+
+~~~~
+sudo docker run -it
+    --net=my-bridge
+    --name=ignite-percipio apacheignite/jobcase:2.4.0 
+~~~~
+
+When attaching a container to a bridge network and it should be reachable from the outside world, port mapping needs to be configured.
+
+### Overlay Networks
+
+A overlay network ([documentation link][3]) allows network communication between containers on separate Docker engine hosts. It is used for so called multi-host network communication. 
+
+Command for defining overlay network (using Swarm and standalone containers):
+
+~~~~
+docker network create -d overlay --attachable --subnet=192.168.10.0/24 my-overlay
+~~~~
+
+Please refer to [link][4] for setting up overlay network without Swarm.
+
+## Running Commands at Container Startup
+
+The docker image makes use of `ENTRYPOINT`. It allows the container to run as executable.
+
+~~~~
+ENTRYPOINT ["/bin/bash", "entrypoint.sh"]
+
+# Set default arguments for ENTRYPOINT
+CMD ["--debug", "--launch", "${IGNITE_HOME}/run.sh &"]
+~~~~
+
+The executable `entrypoint.sh` supports controller command pattern. You can pass-in a list of commands which should be executed at startup.
+
+As default, it executes the Apache Ignite startup script `${IGNITE_HOME}/run.sh &` in background.
+
+You can run additional commands at startup.
+
+Example:
+
+~~~~
+sudo docker run -it
+    --name=ignite-jobcase apacheignite/jobcase:2.4.0 
+    "--launch ${IGNITE_HOME}/run.sh &;${IGNITE_HOME}/control.sh --activate"
+~~~~
+
+## Configuration
+
+### Ports
+
+Only one Ignite instance can run inside the docker container. The docker image does not define port ranges.
+
+The default port values are:
+
+~~~~
+# Ports
+ENV IGNITE_SERVER_PORT 11211
+ENV IGNITE_JMX_PORT 49112
+ENV IGNITE_DISCOVERY_PORT 47500
+ENV IGNITE_COMMUNICATION_PORT 47100
+ENV IGNITE_JDBC_PORT 10800
+ENV IGNITE_REST_PORT 8080
+~~~~
+
+The defined port value(s) can be changed at container startup by passing environment variable.
+E. g. `-e "IGNITE_DISCOVERY_PORT=48001"`. 
+
+
+### Volumes
+
+The docker image defines up-to four volumes.
+
+~~~~
+# JobCase home
+ENV JOBCASE_HOME /opt/jobcase
+
+# Location of configuration files
+ENV JOBCASE_CONFIG ${JOBCASE_HOME}/config
+
+# Location of container log files
+ENV JOBCASE_LOGS ${JOBCASE_HOME}/logs
+
+# root directory where Ignite will persist data, indexes and so on
+ENV IGNITE_PERSISTANT_STORE ${JOBCASE_HOME}/db
+
+# ip dicovery volume
+ENV IGNITE_DISCOVERY /opt/jobcase/discovery
+~~~~
+
+If running the container locally on a development/test machine the log-, persistant- and discovery volumes should be mapped. E. g.
+
+~~~~
+sudo docker run -it
+    -v /Users/mgay/ignite_nodes/logs:/opt/jobcase/logs
+    -v /Users/mgay/ignite_nodes/db:/opt/jobcase/db
+    -v /Users/mgay/ignite_nodes/discovery:/opt/jobcase/discovery
+    --name=ignite-percipio apacheignite/percipiomedia:2.4.0 
+~~~~
+
+### Discovery
+
+The docker image comes with Apache Ignite grid configuration files for three types of node discovery.
+
+#### Multicast
+
+As default, multicast is used for discovering other nodes in the grid.
+
+The configuration file `/opt/jobcase/config/multicast.discovery.node.config.xml` defines the default settings.
+
+#### File
+
+Start container with Apache Ignite file discovery:
+
+~~~~
+    -e "CONFIG_URI=file:///opt/jobcase/config/file.discovery.node.config.xml"
+~~~~
+
+
+#### S3 Bucket
+
+Start container using S3 bucket node discovery:
+
+~~~~
+    -e "CONFIG_URI=file:///opt/jobcase/config/s3bucket.discovery.node.config.xml"
+~~~~
+
+### Grid Persistence
+
+The grid configuration file(s) enable native persistence.  Apache Ignite stores a superset of data on disk, and as much as it can in RAM based on the capacity of the latter. 
+
+The persistence storage folder is located under `/opt/jobcase/db`. A data region called `Default_Region` is created with `[initSize=256.0 MiB, maxSize=2.0 GiB, persistenceEnabled=true]`.
+
+At the moment, our grid configuration creates a unique id for the node by generating a UUID. And it is using the UUID to create a subdirectory under `/opt/jobcase/db`. In the subdirectory Apache Ignite persist the data for the node.
+
+~~~~
+        <!-- As default, it creates a unique id for the node by generating a UUID. 
+             It is used part of the persistent storage folder path. 
+             E. g. persistent storage folder /opt/jobcase/db/node00-49755452-fa53-41d4-82d3-cfff0b830a57.
+             
+             It is recommend to set the consistent id from the outside instead using generated value.
+             <property name="setConsistentId" value=""/>
+         -->
+~~~~
+
+Quote from Apache Ignite documentation [link][5]:
+>To make sure a node gets assigned for a specific subdirectory and, thus, for specific data partitions even after restarts, set IgniteConfiguration.setConsistentId to a unique value cluster-wide. The consistent ID is mapped to UUID from node{IDX}-{UUID} string.
+
+### JVM Garbage Collection
+
+As default, our grid configuration is using G1 garbage collector [link][6].
+
+Default settings in Dockerfile:
+
+~~~~
+# Initial and maximum JVM Heap size
+ENV JVM_HEAP_SIZE 1g
+
+# JVM maximum amount of native memory that can be allocated for class metadata 
+ENV JVM_METASPACE_SIZE 1g
+
+# Ignite JVM settings
+ENV JVM_OPTS="-XX:MaxMetaspaceSize=${JVM_METASPACE_SIZE} -server -Xms${JVM_HEAP_SIZE} -Xmx${JVM_HEAP_SIZE} -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:+DisableExplicitGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M -Xloggc:${JOBCASE_LOGS}/jvm-gc.log"
+~~~~
+
+The default JVM settings can be changed at container startup by passing environment variable `JVM_OPTS` and/or `JVM_HEAP_SIZE` and/or `JVM_METASPACE_SIZE`.
+
+Setting memory values as equivalent in production environment:
+ 
+~~~~
+-e "JVM_METASPACE_SIZE=2g" -e "JVM_HEAP_SIZE=30g"
+~~~~
+
+
+### Events
+
+Our grid configuration registers for a list of events. So it receives notification for the specified events happening in the cluster.
+
+The selected events are so called low frequency events. To avoid performance issues as stated in Apache Ignite documentation (see below quote).
+
+~~~~
+       <property name="includeEventTypes">
+          <list>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CHECKPOINT_SAVED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STARTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STOPPED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_PART_LOADED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_PART_UNLOADED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_TIMEDOUT"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_FAILED_OVER"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_REJECTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_CANCELLED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_TIMEDOUT"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_UNDEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STARTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STOPPED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_JOINED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_LEFT"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_SEGMENTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLIENT_NODE_DISCONNECTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLIENT_NODE_RECONNECTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_DEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_UNDEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_UNDEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_STARTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_STOPPED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_NODES_LEFT"/>
+          </list>
+       </property>       
+~~~~
+
+Quote from Aache Ignite documentation:
+
+> By default, event notifications are turned off for performance reasons.
+
+> Since thousands of events per second are generated, it creates an additional load on the system. This can lead to significant performance degradation. Therefore, it is highly recommended to enable only those events that your application logic requires.
+
+### Logging
+
+TODO
+
+### Ignite REST API
+
+Apache Ignite supports REST protocol [link][1]. 
+
+The API is accessible `http://<docker container ip>:8080/ignite?cmd=version`.
+The default port value is `IGNITE_REST_PORT=80801`.
+
+It can be overwritten by passing environment argument to the `docker run` command:
+
+~~~~
+    -e "IGNITE_REST_PORT=<port value>"
+~~~~
+
+## Appendix
+
+### Mac OS X
+
+The docker integration differs in several areas on Mac OS X. Some aspects are pointed out in the [link FAQS][10].
+
+The Docker Engine starts a Linux VM on Mac OS X.
+
+The below command allows to jump straight into the VM on a Mac.
+
+~~~~
+screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
+~~~~
+
+The Docker Engine for Mac uses a new file system called [link ‘osxfs’][11]. 
+
+#### Networking
+
+The Docker Engine does not create a network interface on Mac [link][12]. As a consequence, you  cannot ping docker containers on your macOS host. And you cannot access the containers by their ip-addresses on your macOS host.
+You have to use port mapping for accessing docker container services on your macOS host.
+
+You can install TUNTAP [link][13] to address the host access limitation. Or you are using port mapping in the association with `org.apache.ignite.configuration.BasicAddressResolver` in the grid configuration file.
+
+When running Mlstore not inside a docker container instead on your macOS host. You have to map ports and define address resolvers if you did not install TUNTAP.
+
+Add addressResolver to `<property name="discoverySpi">`. Replace the container ip-address `172.19.0.2` and macOS host address `192.168.49.117` with your environment values.
+
+~~~~
+                <property name="addressResolver">
+                     <bean class="org.apache.ignite.configuration.BasicAddressResolver">
+                         <constructor-arg>
+                             <map>
+                                 <entry key="172.19.0.2" value="192.168.49.117"/>
+                             </map>
+                         </constructor-arg>
+                     </bean>
+                </property>
+
+~~~~
+
+Add addressResolver to `<property name="communicationSpi">`. And update the ip-address values.
+
+~~~~
+                <property name="addressResolver">
+                     <bean class="org.apache.ignite.configuration.BasicAddressResolver">
+                         <constructor-arg>
+                             <map>
+                                 <entry key="172.19.0.2" value="192.168.49.117"/>
+                             </map>
+                         </constructor-arg>
+                     </bean>
+                </property>                                
+~~~~
+
+Launch the docker container with port mapping for discovery- and communication ports.
+E. g. `-p 47100:47100 -p 47500:47500`.
+
+#### Xterm Display
+
+TODO

--- a/modules/docker/2.4.0-jobcase/prod/Readme.md
+++ b/modules/docker/2.4.0-jobcase/prod/Readme.md
@@ -264,22 +264,30 @@ Start container using S3 bucket node discovery:
 
 The grid configuration file(s) enable native persistence.  Apache Ignite stores a superset of data on disk, and as much as it can in RAM based on the capacity of the latter. 
 
-The persistence storage folder is located under `/opt/jobcase/db`. A data region called `Default_Region` is created with `[initSize=256.0 MiB, maxSize=2.0 GiB, persistenceEnabled=true]`.
+The persistence storage folder is located under `/opt/jobcase/data`. A data region called `Default_Region` is created with `[initSize=256.0 MiB, maxSize=2.0 GiB, persistenceEnabled=true]`.
 
-At the moment, our grid configuration creates a unique id for the node by generating a UUID. And it is using the UUID to create a subdirectory under `/opt/jobcase/db`. In the subdirectory Apache Ignite persist the data for the node.
+As default, our grid configuration creates a unique id for the node by generating a UUID. And it is using the UUID to create a subdirectory under `/opt/jobcase/data`. In the subdirectory Apache Ignite persist the data for the node.
 
 ~~~~
         <!-- As default, it creates a unique id for the node by generating a UUID. 
              It is used part of the persistent storage folder path. 
              E. g. persistent storage folder /opt/jobcase/db/node00-49755452-fa53-41d4-82d3-cfff0b830a57.
              
-             It is recommend to set the consistent id from the outside instead using generated value.
-             <property name="setConsistentId" value=""/>
+             It is recommended that the consistent id is set from the outside instead using generated value.
          -->
+        <property name="consistentId" value="#{systemEnvironment['IGNITE_CONSISTENT_ID']}"/>
 ~~~~
 
 Quote from Apache Ignite documentation [link][5]:
 >To make sure a node gets assigned for a specific subdirectory and, thus, for specific data partitions even after restarts, set IgniteConfiguration.setConsistentId to a unique value cluster-wide. The consistent ID is mapped to UUID from node{IDX}-{UUID} string.
+
+When starting the container, we can define a distinct consistent id value by passing an environment variable:
+
+~~~~
+    -e "IGNITE_CONSISTENT_ID=<mine_id_value>"
+~~~~
+
+
 
 ### JVM Garbage Collection
 

--- a/modules/docker/2.4.0-jobcase/prod/common.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/common.node.config.xml
@@ -21,7 +21,7 @@
   The common.node.config.xml grid configuration file defines settings 
   which are used across different type of deployments.
   
-  It is abstract and cannot be directly used as Ignite configurartion file.
+  It is abstract and cannot be directly used as Ignite configuration file.
   
   The file (Spring application) makes use of environment variable expansion.
   It is using Spring EL syntax like #{systemEnvironment['IGNITE_PERSISTANT_STORE']}.
@@ -50,11 +50,11 @@
              This value should be the same on all nodes in the cluster. -->
         <property name="autoActivationEnabled" value="true"/>
         
-        <!-- As default, it creates a unique id for the node by generating a UUID. 
+        <!-- As default, Ignite creates a unique id for the node by generating a UUID. 
              It is used part of the persistent storage folder path. 
              E. g. persistent storage folder /opt/jobcase/db/node00-49755452-fa53-41d4-82d3-cfff0b830a57.
              
-             It is recommend to set the consistent id from the outside instead using generated value.
+             It is recommended that the consistent id is set from the outside instead using generated value.
              <property name="setConsistentId" value=""/>
          -->
 

--- a/modules/docker/2.4.0-jobcase/prod/common.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/common.node.config.xml
@@ -55,8 +55,8 @@
              E. g. persistent storage folder /opt/jobcase/db/node00-49755452-fa53-41d4-82d3-cfff0b830a57.
              
              It is recommended that the consistent id is set from the outside instead using generated value.
-             <property name="setConsistentId" value=""/>
          -->
+        <property name="consistentId" value="#{systemEnvironment['IGNITE_CONSISTENT_ID']}"/>
 
         <!-- Enabling Apache Ignite native persistence.
              Details https://apacheignite.readme.io/docs/distributed-persistent-store. 

--- a/modules/docker/2.4.0-jobcase/prod/common.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/common.node.config.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- 
+  The common.node.config.xml grid configuration file defines settings 
+  which are used across different type of deployments.
+  
+  It is abstract and cannot be directly used as Ignite configurartion file.
+  
+  The file (Spring application) makes use of environment variable expansion.
+  It is using Spring EL syntax like #{systemEnvironment['IGNITE_PERSISTANT_STORE']}.
+  
+  The list of referenced environment variables is defined in the Dockerfile.
+  When changing environment variable names the Dockerfile and grid configuration file need to be in-sync.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util
+       http://www.springframework.org/schema/util/spring-util.xsd">
+
+   <bean abstract="true" id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <!-- Set to true to enable distributed class loading, default is false. -->
+        <property name="peerClassLoadingEnabled" value="true"/>
+        
+        <!--  Sets failure detection timeout to use in discoverySpi and communicationSpi. -->
+        <property name="failureDetectionTimeout" value="10000"/>
+        
+        <!-- Sets flag indicating whether the cluster is enabled to activate automatically 
+             after all nodes joined of the pre-defined baseline topology.
+             This value should be the same on all nodes in the cluster. -->
+        <property name="autoActivationEnabled" value="true"/>
+        
+        <!-- As default, it creates a unique id for the node by generating a UUID. 
+             It is used part of the persistent storage folder path. 
+             E. g. persistent storage folder /opt/jobcase/db/node00-49755452-fa53-41d4-82d3-cfff0b830a57.
+             
+             It is recommend to set the consistent id from the outside instead using generated value.
+             <property name="setConsistentId" value=""/>
+         -->
+
+        <!-- Enabling Apache Ignite native persistence.
+             Details https://apacheignite.readme.io/docs/distributed-persistent-store. 
+          -->
+        <property name="dataStorageConfiguration">
+            <bean class="org.apache.ignite.configuration.DataStorageConfiguration">
+                <property name="defaultDataRegionConfiguration">
+                    <bean class="org.apache.ignite.configuration.DataRegionConfiguration">
+                        <property name="persistenceEnabled" value="true"/>
+                        
+                        <!-- Increasing the buffer size to 1 GB. -->
+                        <property name="checkpointPageBufferSize" value="#{1024L * 1024 * 1024}"/>
+                        
+                        <property name="name" value="Default_Region"/>
+                        
+                        <!-- Setting the size of the default region to 2GB. -->
+                        <property name="maxSize" value="#{2L * 1024 * 1024 * 1024}"/>                        
+                    </bean>
+                </property>
+                
+                <!-- Set the page size to 4 KB -->
+                <property name="pageSize" value="4096"/>
+                                
+                <!-- Path to the root directory where the Persistent Store will persist data and indexes.                      
+                  -->
+                <property name="storagePath" value="#{systemEnvironment['IGNITE_PERSISTANT_STORE']}"/>
+                
+                <!-- <property name="storagePath" value="/opt/jobcase/db"/>  -->
+                
+                <!-- Sets a path to the directory where WAL is stored. -->                
+                <property name="walPath" value="#{systemEnvironment['IGNITE_PERSISTANT_STORE']}/wal"/>
+                
+                <!-- Sets a path for the WAL archive directory. 
+                     Every WAL segment will be fully copied to this directory 
+                     before it can be reused for WAL purposes. -->                
+                <property name="walArchivePath" value="#{systemEnvironment['IGNITE_PERSISTANT_STORE']}/wal/archive"/>
+            </bean>
+       </property>
+       
+       <!--  Explicitly configure JDBC connector communication -->
+       <property name="clientConnectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ClientConnectorConfiguration">
+                <property name="port" value="#{systemEnvironment['IGNITE_JDBC_PORT']}"/>
+                <property name="portRange" value="1"/>
+            </bean>
+       </property>
+       
+       <!--  Explicitly configure TCP connector communication -->
+       <property name="connectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ConnectorConfiguration">
+                <!-- Binary Client Protocol port -->
+                <property name="port" value="#{systemEnvironment['IGNITE_SERVER_PORT']}"/>
+                <property name="portRange" value="1"/>
+                
+                <!-- Path to Jetty configuration file (REST API configuration).  -->
+                <property name="jettyPath" value="#{systemEnvironment['JOBCASE_CONFIG']}/jetty-config.xml"/>
+            </bean>
+       </property>
+              
+       <!--  Explicitly configure TCP server communication -->
+       <property name="communicationSpi">
+            <bean class="org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi">
+                <property name="localPort" value="#{systemEnvironment['IGNITE_COMMUNICATION_PORT']}"/>
+                <property name="localPortRange" value="1"/>
+                <!-- Maintain connection for outgoing and incoming messages separately. 
+                     Default is false. -->
+                <property name="usePairedConnections" value="false"/>
+            </bean>
+       </property>
+       
+       <!-- Enable cache events. -->
+       <property name="includeEventTypes">
+          <list>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CHECKPOINT_SAVED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STARTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STOPPED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_PART_LOADED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_PART_UNLOADED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_TIMEDOUT"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_FAILED_OVER"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_REJECTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_CANCELLED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_TIMEDOUT"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_UNDEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STARTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_REBALANCE_STOPPED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_JOINED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_LEFT"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_NODE_SEGMENTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLIENT_NODE_DISCONNECTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLIENT_NODE_RECONNECTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_DEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_UNDEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CLASS_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_UNDEPLOYED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_DEPLOY_FAILED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_STARTED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_STOPPED"/>
+            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_NODES_LEFT"/>
+          </list>
+       </property>       
+       
+        <!--
+            Logger to use.
+        -->
+        <property name="gridLogger">
+            <bean class="org.apache.ignite.logger.log4j2.Log4J2Logger">
+                <constructor-arg type="java.lang.String" value="#{systemEnvironment['JOBCASE_CONFIG']}/ignite-log4j2.xml"/>
+            </bean>
+        </property>
+   </bean>
+</beans>

--- a/modules/docker/2.4.0-jobcase/prod/entrypoint.sh
+++ b/modules/docker/2.4.0-jobcase/prod/entrypoint.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Startup controller script for Jobcase Apache Ignite containers
+
+source ./util.sh
+
+function usage() {
+
+  echo "Usage: $0 OPTIONS"
+
+  echo "OPTIONS:"
+  
+  echo "--help      | -h    Display this message"
+  echo "--verbose   | -v    Verbose output"
+  echo "--debug     | -d      Debug/Trace output"
+  echo "--launch    | -l    Command(s) to be executed. \
+                            Use semicolon (;) as separator for passing in more than one command."  
+
+  exit 1
+}
+
+#
+# Parse command line arguments.
+#
+function parse() {
+  # Option strings
+  local SHORT=h,v,d,l:
+  local LONG=help,verbose,debug,launch:
+
+  # read the options
+  local OPTS=$(getopt --options $SHORT --long $LONG --name "$0" -- "$@")
+
+  if [ $? != 0 ] ; then log_error "Failed to parse options...exiting."; exit 1 ; fi
+
+  eval set -- "$OPTS"
+
+  # set initial values
+  VERBOSE=false
+  DEBUG=false
+  LAUNCH_CMD=""
+
+  # extract options and their arguments into variables.
+  while true ; do
+    case "$1" in
+      -h | --help )
+        usage;;
+      -v | --verbose )
+        VERBOSE=true
+        shift
+        ;;
+      -d | --debug )
+        DEBUG=true
+        shift
+        ;;        
+      -l | --launch )
+        LAUNCH_CMD="$2"
+        shift 2
+        ;;        
+      -- )
+        shift
+        break
+        ;;
+      *)
+        log_error "Incorrect parameter: ${1}"; usage;;
+    esac
+  done
+}
+
+#
+# Main function of the shell script.
+#
+function main() {
+  local result
+  local cmd
+  local commands
+  local exit_code
+  local cmd_pid
+  
+  # dump environment into log file
+  log_info "$(env)"
+	
+  # Are launch commands passed-in?
+  if [ -n "${LAUNCH_CMD}" ]; then
+    log_info "launch commands: ${LAUNCH_CMD}"
+  
+    # several launch commands are separated by semicolon
+    # semicolon (;) is set as delimiter
+    IFS=';'      
+      
+    # ${LAUNCH_CMD} is read into an array as tokens separated by IFS  
+    read -ra commands <<< "${LAUNCH_CMD}"
+    
+    # access each element of array
+    for cmd in "${commands[@]}"; do
+      # forcing bash to expand environment variables in the command string	
+      cmd=$(eval echo \"${cmd}\")	
+      
+      log_info "launch: ${cmd}"
+      
+      # execute the passed-in command
+      eval "${cmd}"
+      
+      # the pid of the last background process
+      cmd_pid=$!
+      
+      exit_code=$?
+      
+      log_info "launch result: exit code ${exit_code} process id ${cmd_pid}"
+    done
+    IFS=' '        # reset to default value after usage  
+  fi	
+  tail -f ${LOG_FILE}
+}
+
+parse "$@"
+
+# verbose mode
+if [[ "${VERBOSE}" = true ]]; then
+  log_info "enable verbose mode"
+  set -o verbose
+fi
+
+# debug/trace mode
+if [[ "${DEBUG}" = true ]]; then
+  log_info "enable debug/trace mode"
+  set -o xtrace
+fi
+
+main

--- a/modules/docker/2.4.0-jobcase/prod/file.discovery.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/file.discovery.node.config.xml
@@ -17,11 +17,28 @@
   limitations under the License.
 -->
 
+<!-- 
+  The file.discovery.node.config.xml grid configuration file 
+  defines Shared File System Based Apache Ignite Node Discovery.
+
+  As the default, Apache Ignite is using multicast to discover its nodes.
+  This approach won't work on Amazon AWS and most deployments 
+  which include native and dockerized applications.
+  
+  Sharing a file system allows for successful node discovery.
+  
+  When specifying -e "CONFIG_URI=${JOBCASE_CONFIG}/file.discovery.node.config.xml" 
+  in the docker run command
+  it will use file.discovery.node.config.xml as grid configuration file.
+ -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans.xsd">
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util
+       http://www.springframework.org/schema/util/spring-util.xsd">
        
     <import resource="common.node.config.xml"/>
        
@@ -37,7 +54,7 @@
                 <property name="ipFinder">
                     <!-- local FS discovery using a common mounted volume -->
                     <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.sharedfs.TcpDiscoverySharedFsIpFinder">
-                        <property name="path" value="/opt/jobcase/discovery"/>
+                        <property name="path" value="#{systemEnvironment['IGNITE_DISCOVERY_FS']}"/>
                     </bean>
                 </property>
             </bean>

--- a/modules/docker/2.4.0-jobcase/prod/file.discovery.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/file.discovery.node.config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd">
+       
+    <import resource="common.node.config.xml"/>
+       
+    <!--
+        Alter configuration below as needed.
+    -->
+    <bean parent="grid.cfg">
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="localPort" value="#{systemEnvironment['IGNITE_DISCOVERY_PORT']}"/>
+                <property name="localPortRange" value="1"/>
+                <property name="ipFinder">
+                    <!-- local FS discovery using a common mounted volume -->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.sharedfs.TcpDiscoverySharedFsIpFinder">
+                        <property name="path" value="/opt/jobcase/discovery"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>              
+    </bean>
+</beans>

--- a/modules/docker/2.4.0-jobcase/prod/ignite-log4j2.xml
+++ b/modules/docker/2.4.0-jobcase/prod/ignite-log4j2.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  Jobcase log configuration for Apache Ignite.
+ -->
+<Configuration>
+    <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}] %m%n"/>
+            <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="ACCEPT"/>
+        </Console>
+
+        <Console name="CONSOLE_ERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}] %m%n"/>
+        </Console>
+
+        <Routing name="FILE">
+            <Routes pattern="$${sys:nodeId}">
+                <Route>
+                    <RollingFile name="Rolling-${sys:nodeId}" fileName="${env:JOBCASE_LOGS}/ignite-${sys:nodeId}.log"
+                                 filePattern="${env:JOBCASE_LOGS/ignite-${sys:nodeId}-%i-%d{yyyy-MM-dd}.log.gz">
+                        <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}] %m%n"/>
+                        <Policies>
+                            <TimeBasedTriggeringPolicy interval="6" modulate="true" />
+                            <SizeBasedTriggeringPolicy size="10 MB" />
+                        </Policies>
+                    </RollingFile>
+                </Route>
+            </Routes>
+        </Routing>
+    </Appenders>
+
+    <Loggers>
+        
+        <Logger name="org.apache.ignite" level="INFO"/>
+
+        <!--
+            Uncomment to disable courtesy notices, such as SPI configuration
+            consistency warnings.
+        -->
+        <!--
+        <Logger name="org.apache.ignite.CourtesyConfigNotice" level=OFF/>
+        -->
+
+        <Logger name="org.springframework" level="WARN"/>
+        <Logger name="org.eclipse.jetty" level="WARN"/>
+
+        <!--
+        Avoid warnings about failed bind attempt when multiple nodes running on the same host.
+        -->
+        <Logger name="org.eclipse.jetty.util.log" level="ERROR"/>
+        <Logger name="org.eclipse.jetty.util.component" level="ERROR"/>
+
+        <Logger name="com.amazonaws" level="WARN"/>
+
+        <Root level="INFO">
+            <!-- Uncomment to enable logging to console. -->
+            <!--
+            <AppenderRef ref="CONSOLE" level="DEBUG"/>
+            -->
+
+            <AppenderRef ref="CONSOLE_ERR" level="ERROR"/>
+            <AppenderRef ref="FILE" level="DEBUG"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/modules/docker/2.4.0-jobcase/prod/jetty-config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/jetty-config.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Arg name="threadPool">
+        <!-- Default queued blocking thread pool -->
+        <New class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+            <Set name="minThreads">20</Set>
+            <Set name="maxThreads">200</Set>
+        </New>
+    </Arg>
+    <New id="httpCfg" class="org.eclipse.jetty.server.HttpConfiguration">
+        <Set name="secureScheme">https</Set>
+        <Set name="securePort">8443</Set>
+        <Set name="sendServerVersion">true</Set>
+        <Set name="sendDateHeader">true</Set>
+    </New>
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.ServerConnector">
+                <Arg name="server"><Ref refid="Server"/></Arg>
+                <Arg name="factories">
+                    <Array type="org.eclipse.jetty.server.ConnectionFactory">
+                        <Item>
+                            <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                                <Ref refid="httpCfg"/>
+                            </New>
+                        </Item>
+                    </Array>
+                </Arg>
+                <Set name="host">
+                  <SystemProperty name="IGNITE_JETTY_HOST" default="localhost"/>
+                </Set>
+                <Set name="port">
+                  <SystemProperty name="IGNITE_JETTY_PORT" default="8080"/>
+                </Set>
+                <Set name="idleTimeout">30000</Set>
+                <Set name="reuseAddress">true</Set>
+            </New>
+        </Arg>
+    </Call>
+    <Set name="handler">
+        <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+            <Set name="handlers">
+                <Array type="org.eclipse.jetty.server.Handler">
+                    <Item>
+                        <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+                    </Item>
+                </Array>
+            </Set>
+        </New>
+    </Set>
+    <Set name="stopAtShutdown">false</Set>
+</Configure>

--- a/modules/docker/2.4.0-jobcase/prod/jetty-config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/jetty-config.xml
@@ -17,6 +17,11 @@
   limitations under the License.
 -->
 
+<!--
+  The file defines the Apache Ignite REST API connector.
+  
+  Details https://apacheignite.readme.io/docs/rest-api. 
+ -->
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <Arg name="threadPool">

--- a/modules/docker/2.4.0-jobcase/prod/multicast.discovery.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/multicast.discovery.node.config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd">
+       
+    <import resource="common.node.config.xml"/>
+       
+    <!--
+        Alter configuration below as needed.
+    -->
+    <bean parent="grid.cfg">
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="localPort" value="#{systemEnvironment['IGNITE_DISCOVERY_PORT']}"/>
+                <property name="localPortRange" value="1"/>
+                
+                <!-- Multicast Based Discovery
+                     Multicast to discover other nodes in the grid and is the default IP finder. 
+                     Details: https://apacheignite.readme.io/docs/cluster-config#multicast-based-discovery
+                 -->
+            </bean>
+        </property>              
+    </bean>
+</beans>

--- a/modules/docker/2.4.0-jobcase/prod/multicast.discovery.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/multicast.discovery.node.config.xml
@@ -17,11 +17,21 @@
   limitations under the License.
 -->
 
+<!-- 
+  The mulitcast.discovery.mode.config.xml grid configuration file
+  defines the default node discovery in Apache Ignite.
+  
+  If the grid configuration file does not specify the property ipFinder 
+  it will use multicast for node discovery.  
+ -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans.xsd">
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util
+       http://www.springframework.org/schema/util/spring-util.xsd">
        
     <import resource="common.node.config.xml"/>
        
@@ -36,7 +46,7 @@
                 <property name="localPortRange" value="1"/>
                 
                 <!-- Multicast Based Discovery
-                     Multicast to discover other nodes in the grid and is the default IP finder. 
+                     Multicast to discover other nodes in the grid and it is the default IP finder. 
                      Details: https://apacheignite.readme.io/docs/cluster-config#multicast-based-discovery
                  -->
             </bean>

--- a/modules/docker/2.4.0-jobcase/prod/run.sh
+++ b/modules/docker/2.4.0-jobcase/prod/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ ! -z "$OPTION_LIBS" ]; then
+  IFS=, LIBS_LIST=("$OPTION_LIBS")
+
+  for lib in ${LIBS_LIST[@]}; do
+    cp -r $IGNITE_HOME/libs/optional/"$lib"/* \
+        $IGNITE_HOME/libs/
+  done
+fi
+
+if [ ! -z "$EXTERNAL_LIBS" ]; then
+  IFS=, LIBS_LIST=("$EXTERNAL_LIBS")
+
+  for lib in ${LIBS_LIST[@]}; do
+    echo $lib >> temp
+  done
+
+  wget -i temp -P $IGNITE_HOME/libs
+
+  rm temp
+fi
+
+QUIET=""
+
+if [ "$IGNITE_QUIET" = "false" ]; then
+  QUIET="-v"
+fi
+
+if [ -z $CONFIG_URI ]; then
+  $IGNITE_HOME/bin/ignite.sh $QUIET
+else
+  $IGNITE_HOME/bin/ignite.sh $QUIET $CONFIG_URI
+fi

--- a/modules/docker/2.4.0-jobcase/prod/s3bucket.discovery.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/s3bucket.discovery.node.config.xml
@@ -17,6 +17,15 @@
   limitations under the License.
 -->
 
+<!-- 
+  The s3bucket.discovery.node.config.xml grid configuration file 
+  defines Amazon S3 Node Discovery. 
+  See https://apacheignite-mix.readme.io/docs/amazon-aws#amazon-s3-based-discovery.
+
+  When specifying -e "CONFIG_URI=${JOBCASE_CONFIG}/s3bucket.discovery.node.config.xml" 
+  in the docker run command
+  it will use s3bucket.discovery.node.config.xml as grid configuration file.
+ -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
@@ -37,7 +46,7 @@
                 <property name="ipFinder">
                     <!-- S3 bucket approach for discovery of cluster nodes -->
                     <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.s3.TcpDiscoveryS3IpFinder">
-                        <property name="bucketName" value="staging-mlstore-ignite-discovery-01"/>
+                        <property name="bucketName" value="#{systemEnvironment['IGNITE_DISCOVERY_S3_BUCKETNAME']}"/>
                         <!-- Ideally we would use awsCredentialsProvider here, and use the CredentialsProviderChain below
                              but Ignite comes with an old AWS library that does not include the latter -->
                         <property name="awsCredentials" ref="aws.creds"/>

--- a/modules/docker/2.4.0-jobcase/prod/s3bucket.discovery.node.config.xml
+++ b/modules/docker/2.4.0-jobcase/prod/s3bucket.discovery.node.config.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd">
+       
+    <import resource="common.node.config.xml"/>
+       
+    <!--
+        Alter configuration below as needed.
+    -->
+    <bean parent="grid.cfg">
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="localPort" value="#{systemEnvironment['IGNITE_DISCOVERY_PORT']}"/>
+                <property name="localPortRange" value="1"/>
+                <property name="ipFinder">
+                    <!-- S3 bucket approach for discovery of cluster nodes -->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.s3.TcpDiscoveryS3IpFinder">
+                        <property name="bucketName" value="staging-mlstore-ignite-discovery-01"/>
+                        <!-- Ideally we would use awsCredentialsProvider here, and use the CredentialsProviderChain below
+                             but Ignite comes with an old AWS library that does not include the latter -->
+                        <property name="awsCredentials" ref="aws.creds"/>
+                        <property name="clientConfiguration">
+                            <bean class="com.amazonaws.ClientConfiguration">
+                                 <!-- the default is 3, and in test we had issues where this was not enough to reliably start an instance
+                                     The S3 SLA talks about error rate per 5 minute period.  Circumstantial evidence points to 20s/try timeout  -->
+                                <property name="maxErrorRetry" value="20"/>
+                            </bean>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>              
+    </bean>
+    
+    <!-- The S3 buckets used allow access to Ignite nodes themselves, so we don't need additional credentials.
+         This will use anonymous credentials if no credentials are found -->
+    <bean id="aws.creds" class="com.amazonaws.auth.AnonymousAWSCredentials"/>    
+    
+</beans>

--- a/modules/docker/2.4.0-jobcase/prod/util.sh
+++ b/modules/docker/2.4.0-jobcase/prod/util.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Common shell functions for Jobcase Apache Ignite containers
+
+LOG_DATE='date +%Y/%m/%d:%H:%M:%S'
+LOG_FILE=${JOBCASE_LOGS}/entrypoint.log
+
+#
+# Append log message as INFO to log file.
+# The log message gets written to stdout and log file.
+#
+function log_info {
+  # Check log file exists. 
+  # If the file does not exist it will be created.
+  test -f ${LOG_FILE} || touch ${LOG_FILE}
+  
+  echo `$LOG_DATE`" INFO ${1}" | tee -a ${LOG_FILE}
+}
+
+#
+# Append log message as ERROR to log fie.
+# The log message gets written to stderr and log file.
+#
+function log_error {
+  test -f ${LOG_FILE} || touch ${LOG_FILE}
+	
+  echo `$LOG_DATE`" ERROR ${1}" | tee -a ${LOG_FILE} 1>&2
+}


### PR DESCRIPTION
The pull request includes initial Readme and Dockerfile for prod image.

The Readme.md includes the TODO section:

* Document logging configuration.
* Add logic for setting setConsistentId with host DNS as suffix.
* Add remote debug support.
* Add JMX support.
* Document Xterm support.
* Add command for creating schema for binary objects from file ignite-schema.sql.
* Define and implement healthcheck logic.
* Add optional command for activating grid.
* Add optional command for updating baseline topology.
