### PR TITLE
Merge node address filter logic into 2.7

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/TcpCommunicationSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/TcpCommunicationSpi.java
@@ -49,6 +49,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import org.apache.ignite.Ignite;
@@ -228,6 +230,8 @@ import static org.apache.ignite.spi.communication.tcp.messages.RecoveryLastRecei
  * <li>Socket write timeout (see {@link #setSocketWriteTimeout(long)})</li>
  * <li>Number of received messages after which acknowledgment is sent (see {@link #setAckSendThreshold(int)})</li>
  * <li>Maximum number of unacknowledged messages (see {@link #setUnacknowledgedMessagesBufferSize(int)})</li>
+ * <li>Filtering of reachable addresses (see {@link #setFilterReachableAddresses(boolean)})</li>
+ * <li>Filters to exclude any node addresses which match (see {@link #setNodeAddressExclusionFilters(Set)})</li>
  * </ul>
  * <h2 class="header">Java Example</h2>
  * TcpCommunicationSpi is used by default and should be explicitly configured
@@ -1124,6 +1128,9 @@ public class TcpCommunicationSpi extends IgniteSpiAdapter implements Communicati
 
     /** {@code FILTER_REACHABLE_ADDRESSES} option value for created sockets. */
     private boolean filterReachableAddresses = DFLT_FILTER_REACHABLE_ADDRESSES;
+    
+    /** Set of regular expression patterns used to exclude matching node addresses. */
+    private final Set<Pattern> nodeAddressExclusionFilters = new HashSet<>();
 
     /** Number of received messages after which acknowledgment is sent. */
     private int ackSndThreshold = DFLT_ACK_SND_THRESHOLD;
@@ -1753,6 +1760,43 @@ public class TcpCommunicationSpi extends IgniteSpiAdapter implements Communicati
 
         return this;
     }
+    
+    /**
+     * Gets the regular expression patterns which are used to {@linkplain Matcher#matches filter out}
+     * {@linkplain #nodeAddresses(ClusterNode, boolean) node addresses}. Any address which matches any of
+     * the returned filters is not included in the node addresses for a given {@linkplain ClusterNode node}.
+     * The returned set is unmodifiable.
+     *
+     * @return the set of regular expressions used to filter node addresses
+     */
+    public Set<Pattern> getNodeAddressExclusionFilters() {
+       return Collections.unmodifiableSet(this.nodeAddressExclusionFilters);
+    }
+
+    /**
+     * Sets the regular expressions which are used to {@linkplain Matcher#matches filter out}
+     * {@linkplain #nodeAddresses(ClusterNode, boolean) node addresses}. 
+     * If not provided, no node addresses are filtered.
+     *
+     * @param filterReachableAddresses the set of regular expressions used to filter node addresses
+     * @return {@code this} for chaining.
+     * @throws PatternSyntaxException if any of the given filters are not a 
+     *         {@linkplain Pattern#compile(String) valid} regular expression
+     */
+    @IgniteSpiConfiguration(optional = true)
+    public TcpCommunicationSpi
+       setNodeAddressExclusionFilters(Set<String> nodeAddressExclusionFilters)
+    {
+       Set<Pattern> patterns = new HashSet<>();
+       for(String regex : nodeAddressExclusionFilters) {
+          patterns.add(Pattern.compile(regex));
+       }
+       
+       this.nodeAddressExclusionFilters.clear();
+       this.nodeAddressExclusionFilters.addAll(patterns);
+
+       return this;
+    }   
 
     /**
      * Sets receive buffer size for sockets created or accepted by this SPI.
@@ -3205,6 +3249,30 @@ public class TcpCommunicationSpi extends IgniteSpiAdapter implements Communicati
 
             if (log.isDebugEnabled())
                 log.debug("Addresses to connect for node [rmtNode=" + node.id() + ", addrs=" + addrs + ']');
+        }
+
+        // Apply the configured node address exclusion filters, if any.
+        if(!this.getNodeAddressExclusionFilters().isEmpty()) {
+           final LinkedHashSet<InetSocketAddress> filteredAddrs = new LinkedHashSet<>();
+           for (final InetSocketAddress addr : addrs) {
+              for (final Pattern filter : this.getNodeAddressExclusionFilters()) {
+                 if (filter.matcher(addr.getAddress().getHostAddress()).matches()) {
+                    break;
+                 }
+                 filteredAddrs.add(addr);
+              }
+           }
+   
+           if (filteredAddrs.isEmpty())
+              throw new IgniteCheckedException(
+                 "Failed to send message to the destination node. Node doesn't have any allowable " +
+                    "TCP communication addresses or mapped external addresses (all were filtered out). " +
+                    "Check configuration and make sure that you use the same communication SPI on all nodes. " +
+                    "Remote node id: " + node.id() + ". All possible addresses: " + addrs);
+   
+           addrs = filteredAddrs;
+           if (this.log.isDebugEnabled())
+              this.log.debug("Addresses to connect for node [rmtNode=" + node.id() + ", addrs=" + addrs + ']');
         }
 
         return addrs;

--- a/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/GridTcpCommunicationSpiConfigSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/GridTcpCommunicationSpiConfigSelfTest.java
@@ -17,9 +17,19 @@
 
 package org.apache.ignite.spi.communication.tcp;
 
+import static org.mockito.Matchers.booleanThat;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.ignite.Ignite;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.testframework.junits.spi.GridSpiAbstractConfigTest;
 import org.apache.ignite.testframework.junits.spi.GridSpiTest;
+import org.junit.Assert;
+
+import com.google.common.collect.Sets;
 
 import static org.apache.ignite.testframework.GridTestUtils.getFreeCommPort;
 
@@ -72,4 +82,48 @@ public class GridTcpCommunicationSpiConfigSelfTest extends GridSpiAbstractConfig
     @Override protected void afterTestsStopped() {
         stopAllGrids();
     }
+    
+    public void testNodeAddressExclusionFilters() throws Exception {
+       try {
+           IgniteConfiguration cfg = getConfiguration();
+
+           TcpCommunicationSpi spi = new TcpCommunicationSpi();
+           cfg.setCommunicationSpi(spi);
+
+           Ignite ignite = startGrid(cfg.getIgniteInstanceName(), cfg);
+           
+
+           // Validate the node addresses for the only node contains the local node address.
+           Collection<InetSocketAddress> unfilteredAddresses = spi.nodeAddresses(ignite.cluster().node(), false);
+           boolean containsLocalAddress = false;      
+           for(InetSocketAddress unfilteredAddress : unfilteredAddresses) {
+              if(unfilteredAddress.getAddress().getHostAddress().equals("127.0.0.1")) {
+                 containsLocalAddress = true;
+                 break;
+              }
+           }
+           Assert.assertTrue(containsLocalAddress);
+           
+           // Tell the SPI to filter the local address and make sure it isn't returned by nodeAddress().
+           spi.setNodeAddressExclusionFilters(Sets.newHashSet("127[.]0[.]0[.]1"));
+           containsLocalAddress = false;      
+           Collection<InetSocketAddress> filteredAddresses = spi.nodeAddresses(ignite.cluster().node(), false);   
+           for(InetSocketAddress filteredAddress : filteredAddresses) {
+              if(filteredAddress.getAddress().getHostAddress().equals("127.0.0.1")) {
+                 containsLocalAddress = true;
+                 break;
+              }
+           }
+           Assert.assertFalse(containsLocalAddress);
+           
+           // Try to configure an invalid filter.
+           boolean filterInvalid = false;
+           try {
+              spi.setNodeAddressExclusionFilters(Sets.newHashSet("["));
+           } catch (PatternSyntaxException e) {
+              filterInvalid = true;
+           }
+           Assert.assertTrue(filterInvalid);
+       }
+   }
 }


### PR DESCRIPTION
Cherry picked 'a0c77167ed (HEAD -> ignite-2.5, origin/ignite-2.5) Merge pull request #126 from percipiomedia/node_address_filter' from branch ignite-2.5.