### PR TITLE
Using openjdk 11 runtime in Ignite image

### DIFF
--- a/bin/control.sh
+++ b/bin/control.sh
@@ -142,14 +142,26 @@ fi
 #
 # Final JVM_OPTS for Java 9 compatibility
 #
-${JAVA_HOME}/bin/java -version 2>&1 | grep -qE 'java version "9.*"' && {
-JVM_OPTS="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+javaMajorVersion "${JAVA_HOME}/bin/java"
+
+if [ $version -gt 8 ] && [ $version -lt 11 ]; then
+  JVM_OPTS="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
           --add-exports jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
           --add-modules java.xml.bind \
       ${JVM_OPTS}"
-} || true
+elif [ $version -eq 11 ] ; then
+  JVM_OPTS="\
+        --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+        --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
+        --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
+        --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
+        --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
+        --illegal-access=permit \
+        ${JVM_OPTS}"
+fi
+
 
 ERRORCODE="-1"
 

--- a/docker/apache-ignite-jobcase/prod/Dockerfile
+++ b/docker/apache-ignite-jobcase/prod/Dockerfile
@@ -20,19 +20,10 @@
 #
 
 # Debian package
-FROM debian:stretch
+FROM openjdk:11.0.1-jdk
 
 # Ignite version
 ENV IGNITE_VERSION 2.7.0
-
-# Oracle JDK Linux x64 download information
-ENV JAVA_VERSION=8 \
-    JAVA_UPDATE=192 \
-    JAVA_BUILD=12 \
-    JAVA_PATH=750e1c8617c5452694857ad95c3ee230
-
-# Java home
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-oracle
 
 # JobCase home
 ENV JOBCASE_HOME /opt/jobcase
@@ -105,7 +96,8 @@ ENV JVM_ADDITIONAL_OPTS ""
 ENV JVM_OPTS="-server -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:+DisableExplicitGC -XX:-UseContainerSupport -Djava.net.preferIPv4Stack=true"
 
 # GC logging is only for Ignite itself, not utilities like Visor or control.sh
-ENV JVM_IGNITE_GC_LOGGING_OPTS="-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
+# The filesize is in kilobyte.
+ENV JVM_IGNITE_GC_LOGGING_OPTS="-Xlog:gc*:debug:time,uptime:filecount=10,filesize=100000"
 
 # Set to true for client mode.  NOTE: The config file must use this variable for it to be effective.
 ENV IGNITE_CLIENT_MODE false
@@ -125,18 +117,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         netcat-openbsd \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p ${JOBCASE_LOGS}
-
-# Install Oracle JDK and Java Cryptography Extension (JCE) Unlimited Strength
-RUN cd "/tmp" && \
-    wget --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-        "http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD}/${JAVA_PATH}/jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" && \
-    tar -xzf "jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" && \
-    mkdir -p "/usr/lib/jvm" && \
-    mv "/tmp/jdk1.${JAVA_VERSION}.0_${JAVA_UPDATE}" "${JAVA_HOME}" && \
-    wget --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-        "http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION}/jce_policy-${JAVA_VERSION}.zip" && \
-    unzip -jo -d "${JAVA_HOME}/jre/lib/security" "jce_policy-${JAVA_VERSION}.zip" && \
-    rm /tmp/*
 
 # Copy apache ignite binaries
 COPY ./apache-ignite-${IGNITE_VERSION}-SNAPSHOT-bin ${IGNITE_HOME}/

--- a/docker/apache-ignite-jobcase/prod/Dockerfile
+++ b/docker/apache-ignite-jobcase/prod/Dockerfile
@@ -96,8 +96,7 @@ ENV JVM_ADDITIONAL_OPTS ""
 ENV JVM_OPTS="-server -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:+DisableExplicitGC -XX:-UseContainerSupport -Djava.net.preferIPv4Stack=true"
 
 # GC logging is only for Ignite itself, not utilities like Visor or control.sh
-# The filesize is in kilobyte.
-ENV JVM_IGNITE_GC_LOGGING_OPTS="-Xlog:gc*:debug:time,uptime:filecount=10,filesize=100000"
+ENV JVM_IGNITE_GC_LOGGING_OPTS="-Xlog:gc*:debug:time,uptime:filecount=10,filesize=100m"
 
 # Set to true for client mode.  NOTE: The config file must use this variable for it to be effective.
 ENV IGNITE_CLIENT_MODE false

--- a/docker/apache-ignite-jobcase/prod/autobaseline.sh
+++ b/docker/apache-ignite-jobcase/prod/autobaseline.sh
@@ -9,44 +9,43 @@ export JVM_OPTS=
 
 # Activate or set a baseline for all current server nodes, but only after a while.
 if [ ! -z "$IGNITE_CONSISTENT_ID" ]  && [ "$IGNITE_AUTO_BASELINE_DELAY" -ne 0 ]
-then 
+then
     sleep $IGNITE_AUTO_BASELINE_DELAY
-    
+
     $IGNITE_HOME/bin/control.sh --baseline > /tmp/baseline
     if [ $? -eq 0 ]
-    then     
+    then
 
         X=`egrep "Cluster state.* active" /tmp/baseline`
         if [ $? -ne 0 ]
-        then 
+        then
             X=`egrep "inactive" /tmp/baseline`
             if [ "$?" -eq 0 ]
             then
-            
+
                 # cluster is not active
                 # case 1: new cluster - want to activate
                 # case 2: cluster restarting without all baseline nodes or perhaps some new nodes - activation risks data loss.
-                
-                # if there 
-                X=`grep "Baseline nodes not found." /tmp/baseline` 
-                if [ "$?" -eq 0 ] 
-                then             
+
+                # if there
+                X=`grep "Baseline nodes not found." /tmp/baseline`
+                if [ "$?" -eq 0 ]
+                then
                     $IGNITE_HOME/bin/control.sh --activate
-                fi      
+                fi
             # else did not get a baseline, just bail out
             fi
         else
             # this cluster is already active
             # case 1:  new nodes added to expand cluster, use them
             # case 2:  new nodes are replacements for failed nodes, use them, because cluster is already active
-            
-            
-            X=`sed -n '/Other/q;p' /tmp/baseline | grep "ConsistentID=${IGNITE_CONSISTENT_ID}"` 
+
+
+            X=`sed -n '/Other/q;p' /tmp/baseline | grep "ConsistentID=${IGNITE_CONSISTENT_ID}"`
             if [ $? -ne 0 ]; then
                 VERSION=`grep "Current topology version" /tmp/baseline | grep -oP '\d+'`
-                $IGNITE_HOME/bin/control.sh --baseline version $VERSION --force
+                $IGNITE_HOME/bin/control.sh --baseline version $VERSION --yes
             fi
         fi
     fi
 fi
-      

--- a/docker/apache-ignite-jobcase/prod/autobaseline.sh
+++ b/docker/apache-ignite-jobcase/prod/autobaseline.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source ./util.sh
+
 # Add this and all nodes to the baseline after waiting for the delay time
 IGNITE_CONSISTENT_ID=$1
 IGNITE_AUTO_BASELINE_DELAY=$2
@@ -15,6 +18,7 @@ then
     $IGNITE_HOME/bin/control.sh --baseline > /tmp/baseline
     if [ $? -eq 0 ]
     then
+        log_info "baseline info: $(cat /tmp/baseline)"
 
         X=`egrep "Cluster state.* active" /tmp/baseline`
         if [ $? -ne 0 ]

--- a/docker/apache-ignite-jobcase/prod/run.sh
+++ b/docker/apache-ignite-jobcase/prod/run.sh
@@ -78,7 +78,7 @@ fi
 export JVM_OPTS="$JVM_OPTS $JVM_DEBUG_OPTS $JVM_ADDITIONAL_OPTS"
 
 if [ ! -z "${JVM_IGNITE_GC_LOGGING_OPTS}" ] &&  [ ! -z "${JOBCASE_LOGS}" ]; then
-    export JVM_OPTS="$JVM_OPTS $JVM_IGNITE_GC_LOGGING_OPTS  -Xloggc:${JOBCASE_LOGS}/jvm-gc.log"
+    export JVM_OPTS="$JVM_OPTS $JVM_IGNITE_GC_LOGGING_OPTS:file=${JOBCASE_LOGS}/jvm-gc.log"
 fi
 
 if [ ! -z "${JVM_METASPACE_SIZE}" ]; then

--- a/modules/aws/pom.xml
+++ b/modules/aws/pom.xml
@@ -157,6 +157,14 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- JVM 11 missing packages -->
+		<dependency>
+	      <groupId>javax.xml.bind</groupId>
+	      <artifactId>jaxb-api</artifactId>
+	      <version>${jaxb.api.version}</version>
+	    </dependency>
+
     </dependencies>
 
     <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -131,6 +131,9 @@
         <osgi.embed.transitive>false</osgi.embed.transitive>
         <osgi.fail.ok>false</osgi.fail.ok>
 
+		<!-- JVM 11 missing packages -->
+		<jaxb.api.version>2.3.0</jaxb.api.version>
+
     </properties>
 
     <groupId>org.apache.ignite</groupId>


### PR DESCRIPTION
Our goal is to move to Open JDK 11 for everything, as we containerize. As the minimum, we are using the Open JDK 11 JVM for runtime. Compiling the code using JDK 11 compiler will be later done.

Background: There won't be any new free of cost updates to Oracle JDK after January 1st, 2019. Open JDK 11 has free Long-Term Support until 2024. 