### PR TITLE
Add support for nodes discovery in Kubernetes

### DIFF
--- a/docker/apache-ignite-jobcase/Readme.md
+++ b/docker/apache-ignite-jobcase/Readme.md
@@ -38,7 +38,7 @@ Docker Image:
 Docker Container:
 > * A container is a runnable instance of an image. You can create, start, stop, move, or delete a container using the Docker API or CLI. You can connect a container to one or more networks, attach storage to it, or even create a new image based on its current state.*
 
-## Links
+## Resources
 
 * [1]: https://apacheignite.readme.io/docs/rest-api/ "Apache Ignite REST-API"
 * [2]: https://docs.docker.com/engine/tutorials/networkingcontainers/ "Networking Containers"
@@ -55,6 +55,8 @@ Docker Container:
 * [13]: https://github.com/mal/docker-for-mac-host-bridge "Docker for Mac - Host Bridge"
 * [14]: https://apacheignite.readme.io/docs/binary-marshaller "Apache Ignite Binary Marshaller"
 * [15]: https://apacheignite-sql.readme.io/docs/system-views "Apache Ignite SQL System Views"
+* [16]: https://apacheignite-mix.readme.io/docs/kubernetes-discovery
+* [17]: https://github.p11a.com/helm-charts/apache-ignite
 
 ## Build
 
@@ -287,6 +289,19 @@ Start container using S3 bucket node discovery:
 ~~~~
     -e "CONFIG_URI=file:///opt/jobcase/config/s3bucket.discovery.node.config.xml"
 ~~~~
+
+#### Kubernetes
+
+Start container with Apache Ignite Kubernetes discovery:
+
+~~~~
+    -e "CONFIG_URI=file:///opt/jobcase/config/kubernetes.discovery.node.config.xml"
+    -e "IGNITE_CONSISTENT_ID=<pod name>"
+    -e "IGNITE_DISCOVERY_KUBE_SERVICE_NAME=<kubernetes service name>"
+    -e "IGNITE_DISCOVERY_KUBE_NAMESPACE=<namespace of the kubernetes service>"
+~~~~
+
+The Github repository [Jobcase Apache Ignite chart](https://github.p11a.com/helm-charts/apache-ignite) includes the Helm chart for deploying Apache Ignite into Kubernetes cluster.
 
 ### Grid Persistence
 

--- a/docker/apache-ignite-jobcase/prod/Dockerfile
+++ b/docker/apache-ignite-jobcase/prod/Dockerfile
@@ -153,6 +153,10 @@ COPY ./apache-ignite-${IGNITE_VERSION}-SNAPSHOT-bin/libs/optional/ignite-aws ${I
 # Enable AOP support
 COPY ./apache-ignite-${IGNITE_VERSION}-SNAPSHOT-bin/libs/optional/ignite-aop ${IGNITE_HOME}/libs/ignite-aop/
 
+# Enable TCP Discovery IP Finder that uses a dedicated Kubernetes service
+# for IP addresses lookup of Apache Ignite pods containerized by Kubernetes.
+COPY ./apache-ignite-${IGNITE_VERSION}-SNAPSHOT-bin/libs/optional/ignite-kubernetes ${IGNITE_HOME}/libs/ignite-kubernetes/
+
 # Add snapshot manger plugin jar to distribution
 # See https://github.p11a.com/mgay/snapshot-manager-plugin
 COPY ./target/dependency/snapshot-manager-plugin-${IGNITE_VERSION}-SNAPSHOT.jar ${IGNITE_HOME}/libs/
@@ -171,6 +175,9 @@ COPY ./file.discovery.node.config.xml ${JOBCASE_CONFIG}/
 
 # Copy s3 bucket discovery grid configuration file
 COPY ./s3bucket.discovery.node.config.xml ${JOBCASE_CONFIG}/
+
+# Copy kubernetes discovery grid configuration file
+COPY ./kubernetes.discovery.node.config.xml ${JOBCASE_CONFIG}/
 
 # Copy default grid configuration file
 COPY ./multicast.discovery.node.config.xml ${JOBCASE_CONFIG}/

--- a/docker/apache-ignite-jobcase/prod/kubernetes.discovery.node.config.xml
+++ b/docker/apache-ignite-jobcase/prod/kubernetes.discovery.node.config.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  The kubernetes.discovery.node.config.xml grid configuration file
+  defines Kubernetes Node Discovery.
+  See https://apacheignite-mix.readme.io/docs/kubernetes-discovery.
+
+  When specifying -e "CONFIG_URI=${JOBCASE_CONFIG}/kubernetes.discovery.node.config.xml"
+  it will use kubernetes.discovery.node.config.xml as grid configuration file.
+
+  The consistent id needs explicitly specified for each pod by setting
+  the environment variable "IGNITE_CONSISTENT_ID".
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util
+       http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <import resource="common.node.config.xml"/>
+
+    <!--
+        Alter configuration below as needed.
+    -->
+    <bean parent="grid.cfg">
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="localPort" value="#{systemEnvironment['IGNITE_DISCOVERY_PORT']}"/>
+                <property name="localPortRange" value="#{systemEnvironment['IGNITE_PORT_RANGE']}"/>
+
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.kubernetes.TcpDiscoveryKubernetesIpFinder">
+                       <property name="serviceName" value="#{systemEnvironment['IGNITE_DISCOVERY_KUBE_SERVICE_NAME']}"/>
+                       <property name="namespace" value="#{systemEnvironment['IGNITE_DISCOVERY_KUBE_NAMESPACE']}"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/docker/apache-ignite-jobcase/prod/run.sh
+++ b/docker/apache-ignite-jobcase/prod/run.sh
@@ -42,6 +42,8 @@ if [ -e "$IGNITE_PERSISTENT_STORE/host.info" ]; then
 fi
 
 # form a consistent ID from the ECS host's name and the cluster name
+# It only applies for ECS environment.
+# In any other environment, the environment variable needs explicitly specified.
 if [ -z "$IGNITE_CONSISTENT_ID" ]; then
     if [ -z $IGNITE_CONSISTENT_ID_PREFIX ]; then
          IGNITE_CONSISTENT_ID_PREFIX=${IGNITE_CLUSTER_NAME}


### PR DESCRIPTION
The Kubernetes Discovery uses a Kubernetes service that maintains a list
of the IP addresses.

The repository https://github.p11a.com/helm-charts/apache-ignite will include the helm chart for deployment. At the moment, we are only going to use Kubernetes for testing purposes.